### PR TITLE
ci(Makefile): use titan fork version for ignite

### DIFF
--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: orijtech/consensuswarn@main
         with:
-          roots: "github.com/titantkx/titan/app.BaseApp.DeliverTx,github.com/titantkx/titan/app.BaseApp.BeginBlocker,github.com/titantkx/titan/app.BaseApp.EndBlocker"
+          roots: "github.com/titantkx/titan/app.App.DeliverTx,github.com/titantkx/titan/app.App.BeginBlocker,github.com/titantkx/titan/app.App.EndBlocker"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Types of changes (Stanzas):
 "Client Breaking" for breaking CLI commands and REST routes used by end-users.
 "API Breaking" for breaking exported APIs used by developers building on SDK.
 "State Machine Breaking" for any changes that result in a different AppState given same genesisState and txList.
+"Miscellaneous" for anything else.
 
 Ref: https://keepachangelog.com/en/1.1.0/
 -->
@@ -36,5 +37,9 @@ Ref: https://keepachangelog.com/en/1.1.0/
 # Changelog
 
 ## Unreleased
+
+### Miscellaneous
+
+- (Makefile) Update to use fork version of ignite cli.
 
 ## [v2.0.1](https://github.com/titantkx/titan/releases/tag/v2.0.1)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ HTTPS_GIT := https://github.com/titantkx/titan.git
 DOCKER := $(shell which docker)
 PROJECT_NAME = $(shell git remote get-url origin | xargs basename -s .git)
 COSMOS_VERSION = $(shell go list -m github.com/cosmos/cosmos-sdk | sed 's:.* ::')
-IGNITE_VERSION = v0.27.2
+IGNITE_VERSION = v0.27.2-titan.1
 MOCKS_DIR = $(CURDIR)/tests/mocks
 DOCKER_IMAGE := titantkx/titand
 
@@ -221,8 +221,8 @@ update-swagger-docs-by-ignite:
 ignite:
 	@echo "Installing ignite (tag ${IGNITE_VERSION}) ..."
 	rm -rf ignite_tmp	
-	git clone --depth 1 --branch ${IGNITE_VERSION} https://github.com/ignite/cli.git ignite_tmp	
-	cd ignite_tmp && go get golang.org/x/mod@v0.12.0 && go mod tidy && make install
+	git clone --depth 1 --branch ${IGNITE_VERSION} https://github.com/titantkx/ignite-cli.git ignite_tmp
+	cd ignite_tmp && make install
 	rm -rf ignite_tmp
 
 cosmovisor:


### PR DESCRIPTION
# Description

Use titan fork version of ignite to apply 2 pr

- [#3654](https://github.com/ignite/cli/pull/3654)
- [#3656](https://github.com/ignite/cli/pull/3656)

***`Consensus Warn` action fail because wrong config roots package. That also have corrected in [this PR](https://github.com/titantkx/titan/pull/72/files#diff-1129c15552d9d50c09782f8d9a95fcb84a76ed89831e6e2059443119a375c3b9).***

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the correct branch (see [PR Targeting](https://github.com/titantkx/titan/blob/develop/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [x] confirmed all author checklist items have been addressed
- [x] reviewed content
- [x] confirmed all CI checks have passed
