### PR TITLE
fix(app): correct init AccountKeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ Ref: https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+## [v3.0.0](https://github.com/titantkx/titan/releases/tag/v3.0.0)
+
+### Improvements
+
+- (deps) upgrade cosmos-sdk to v0.47.6-titan.8
+
+### Miscellaneous
+
+- Fix upgrade test
+
 ## [v3.0.0-rc.0](https://github.com/titantkx/titan/releases/tag/v3.0.0-rc.0)
 
 ### State Machine Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Ref: https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- (app) Correct init AccountKeeper with address prefix "titan" instead of "cosmos".
+
 ## [v3.0.0](https://github.com/titantkx/titan/releases/tag/v3.0.0)
 
 ### Improvements

--- a/app/app.go
+++ b/app/app.go
@@ -457,7 +457,7 @@ func New(
 		keys[authtypes.StoreKey],
 		ethermint.ProtoAccount,
 		MaccPerms,
-		sdk.Bech32PrefixAccAddr,
+		AccountAddressPrefix,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 


### PR DESCRIPTION
# Description

Correct init AccountKeeper with address prefix "titan"

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] left instructions on how to review the changes
- [x] targeted the correct branch (see [PR Targeting](https://github.com/titantkx/titan/blob/develop/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed content
- [ ] confirmed all CI checks have passed
